### PR TITLE
delete_schedule_index_and_when_add_schedule_go_to_mypage

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,8 @@ class UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     @user.update(user_params)
-    redirect_to users_schedule_path(id: params[:id])
+    flash[:notice] = "スケジュールを更新しました。"
+    redirect_to show_users_path(id: params[:id])
   end
 
   def show_schedule


### PR DESCRIPTION
スケジュールを登録したら、マイページに飛ばして、noticeで予定入力しました

 スケジュールインデックスに飛ぶ必要はなくしました